### PR TITLE
[DD-839][DD-1274] Rework transformation arrows

### DIFF
--- a/yo/app/index.html
+++ b/yo/app/index.html
@@ -126,7 +126,7 @@
         <script src="scripts/services/gdm-parser.js"></script>
         <script src="scripts/services/filter-helper.js"></script>
         <script src="scripts/services/js-plumb.js"></script>
-        <script src="scripts/services/mapping-arrows.js"></script>
+        <script src="scripts/services/transformation-arrows.js"></script>
         <script src="scripts/services/pubsub.js"></script>
         <script src="scripts/services/util.js"></script>
         <script src="scripts/services/convert-units.js"></script>

--- a/yo/app/index.html
+++ b/yo/app/index.html
@@ -126,6 +126,7 @@
         <script src="scripts/services/gdm-parser.js"></script>
         <script src="scripts/services/filter-helper.js"></script>
         <script src="scripts/services/js-plumb.js"></script>
+        <script src="scripts/services/mapping-arrows.js"></script>
         <script src="scripts/services/pubsub.js"></script>
         <script src="scripts/services/util.js"></script>
         <script src="scripts/services/convert-units.js"></script>

--- a/yo/app/index.html
+++ b/yo/app/index.html
@@ -128,6 +128,7 @@
         <script src="scripts/services/js-plumb.js"></script>
         <script src="scripts/services/pubsub.js"></script>
         <script src="scripts/services/util.js"></script>
+        <script src="scripts/services/convert-units.js"></script>
         <script src="scripts/services/file-download.js"></script>
         <script src="scripts/services/file-upload.js"></script>
         <script src="scripts/services/data-config-text.js"></script>

--- a/yo/app/scripts/controllers/model.js
+++ b/yo/app/scripts/controllers/model.js
@@ -694,6 +694,7 @@ angular.module('dmpApp')
         $scope.onCloseTransformationSelectorClick = function() {
             hideFunctionConfiguration();
             hideOverlayData();
+            PubSub.broadcast('jsp-connector-disconnect', { type: [ 'transformation', 'component' ]  });
 
             $timeout(function() {
                 PubSub.broadcast('projectModelChanged', {});

--- a/yo/app/scripts/directives/dmp-endpoint.js
+++ b/yo/app/scripts/directives/dmp-endpoint.js
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2013 – 2015  SLUB Dresden & Avantgarde Labs GmbH (<code@dswarm.org>)
- *  
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -209,8 +209,13 @@ angular.module('dmpApp')
 
                 }
 
+                // If a labels is given _and_ it is a string, it is assumed (heuristically),
+                // that the connection already existed, e.g. after closing the
+                // mapping view or opening a work-in-progress project.
+                // In this case, do not fire the open event, as this confuses the
+                // mapping view.
                 if (active) {
-                    activate(newConnection);
+                    activate(newConnection, angular.isString(data));
                 }
 
                 component.connection = newConnection;

--- a/yo/app/scripts/directives/transformation.js
+++ b/yo/app/scripts/directives/transformation.js
@@ -190,31 +190,11 @@ angular.module('dmpApp')
             PubSub.broadcast('jsp-connector-disconnect', { type: [ 'transformation', 'component' ]  });
         }
 
-        var showTransformationPlumbsTimeout = null;
-
-        /**
-         * Initializes show of all transformations. Saves timeout to prevent multiple
-         * events running into each other
-         * @param {number} [time] - Timeout time to show plumbs
-         */
-        function showTransformationPlumbsInit(time) {
-
-            time = typeof time !== 'undefined' ? time : 100;
-
-            if(showTransformationPlumbsTimeout && showTransformationPlumbsTimeout.then) {
-                $timeout.cancel(showTransformationPlumbsTimeout);
-            }
-
-            showTransformationPlumbsTimeout = $timeout(function() {
-                showTransformationPlumbs();
-            }, time);
-
-        }
 
         /**
          * The real function to show transformations. Use only via init function
          */
-        function showTransformationPlumbs() {
+        function _showTransformationPlumbs() {
 
             var connectOptions = { type : 'transformation' };
 
@@ -306,6 +286,10 @@ angular.module('dmpApp')
 
 
         }
+
+        var showTransformationPlumbs = loDash.debounce(function() {
+            $scope.$apply(_showTransformationPlumbs);
+        }, 500);
 
         //** End functions to create plumbs
 
@@ -694,7 +678,7 @@ angular.module('dmpApp')
 
             });
 
-            showTransformationPlumbsInit();
+            showTransformationPlumbs();
         }
 
         PubSub.subscribe($rootScope, ['DRAG-START'], function() {
@@ -814,7 +798,7 @@ angular.module('dmpApp')
 
             }
 
-            showTransformationPlumbsInit();
+            showTransformationPlumbs();
 
         }
 
@@ -1078,7 +1062,7 @@ angular.module('dmpApp')
 
             setGridHeight($scope.activeMapping.input_attribute_paths.length);
 
-            showTransformationPlumbsInit();
+            showTransformationPlumbs();
 
             updateInputOutputMappings();
 
@@ -1474,7 +1458,7 @@ angular.module('dmpApp')
 
                 $scope.onFunctionClick(currentItem, true);
 
-                showTransformationPlumbsInit();
+                showTransformationPlumbs();
 
             });
 

--- a/yo/app/scripts/directives/transformation.js
+++ b/yo/app/scripts/directives/transformation.js
@@ -184,12 +184,15 @@ angular.module('dmpApp')
         /**
          * Hides all transformations
          */
-        function hideTransformationPlumbs() {
+        function _hideTransformationPlumbs() {
             $scope.transformationStateError = '';
 
             PubSub.broadcast('jsp-connector-disconnect', { type: [ 'transformation', 'component' ]  });
         }
 
+        var hideTransformationPlumbs = loDash.debounce(function() {
+            $scope.$apply(_hideTransformationPlumbs);
+        }, 100);
 
         /**
          * The real function to show transformations. Use only via init function

--- a/yo/app/scripts/services/convert-units.js
+++ b/yo/app/scripts/services/convert-units.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2013 – 2015  SLUB Dresden & Avantgarde Labs GmbH (<code@dswarm.org>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+angular.module('dmpApp')
+    .factory('convertUnits', function($document, $window) {
+
+        var doc = $document[0],
+            dummyDiv = doc.createElement('div');
+
+        dummyDiv.id = 'for-size-calculations-ignore-otherwise';
+        // Chrome needs this appended to the DOM, otherwise it won't
+        // compute any styles.
+        doc.body.appendChild(dummyDiv);
+
+        function em2px(ems) {
+            dummyDiv.style.width = ems + 'em';
+            return parseInt($window.getComputedStyle(dummyDiv).width, 10);
+        }
+
+        return {
+            em2px: em2px
+        };
+    });

--- a/yo/app/scripts/services/js-plumb-connector.js
+++ b/yo/app/scripts/services/js-plumb-connector.js
@@ -16,7 +16,7 @@
 'use strict';
 
 angular.module('dmpApp')
-    .directive('jsPlumbConnector', function ($rootScope, jsP, mappingArrows) {
+    .directive('jsPlumbConnector', function ($rootScope, jsP, transformationArrows) {
 
         $rootScope.$on('$locationChangeStart', function() {
             jsP.detachEveryConnection({});
@@ -32,13 +32,13 @@ angular.module('dmpApp')
                         return scope.$eval(jsPlumbConnectorIdentItem);
                     };
 
-                mappingArrows.clear();
+                transformationArrows.clear();
 
                 return function(scope, iElement) {
                     var identItem = jsPlumbConnectorIdentItemWatch(scope),
                         identType = tAttrs['jsPlumbConnectorIdentType'];
 
-                    scope.guid = mappingArrows.register(identItem, identType);
+                    scope.guid = transformationArrows.register(identItem, identType);
                     iElement.attr('id', scope.guid);
                 };
             }

--- a/yo/app/scripts/services/js-plumb-connector.js
+++ b/yo/app/scripts/services/js-plumb-connector.js
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2013 – 2015  SLUB Dresden & Avantgarde Labs GmbH (<code@dswarm.org>)
- *  
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,190 +16,30 @@
 'use strict';
 
 angular.module('dmpApp')
-    .directive('jsPlumbConnector', function ($rootScope, jsP, PubSub, GUID, loDash) {
-
-        var connectorMap = [],
-            connectorEndpointMap = [],
-            connectorConnectionMap = [],
-            defaultOpts = {
-                scope: 'schema',
-                container: 'schema',
-                anchor: 'Continuous',
-                endpoint: ['Dot', {
-                    radius: 5,
-                    cssClass: 'source-endpoint'
-                }],
-                connectorOverlays: [
-                    ['Arrow', {
-                        location: 1,
-                        width: 10,
-                        length: 12,
-                        foldback: 0.75
-                    }]
-                ],
-                connector: 'StateMachine',
-                connectorStyle: {
-                    strokeStyle: 'black',
-                    lineWidth: 3
-                },
-                paintStyle: {
-                    fillStyle: 'black',
-                    lineWidth: 3
-                }
-            };
-
-        function createConnection(selectors, options, type) {
-
-            options = angular.extend({}, defaultOpts, options);
-
-            var endpoints = createEndpoints(selectors, options, type);
-
-            var connection = connect(endpoints[0], endpoints[1]);
-
-            connectorConnectionMap.push({
-                type: type,
-                connection: connection
-            });
-
-            return connection;
-        }
-
-        function createEndpoints(selectors, options, type) {
-
-            var endpoints = [];
-
-            angular.forEach(selectors, function(selector) {
-
-                var endpoint = createEndpoint(selector, options);
-
-                connectorEndpointMap.push({
-                    type: type,
-                    endpoint: endpoint
-                });
-
-                endpoints.push(endpoint);
-            });
-
-            return endpoints;
-        }
-
-        function createEndpoint(selector, options) {
-
-            return jsP.addEndpoint(selector, options);
-
-        }
-
-        function connect(sourceEndpoint, targetEndpoint) {
-
-            var connection = jsP.connect(sourceEndpoint, targetEndpoint);
-
-            return connection;
-        }
-
-        function onConnectorConnect(options) {
-
-            var target = loDash.filter(connectorMap, { 'ident': { type: options.target.type, uuid: options.target.uuid} });
-            var source = loDash.filter(connectorMap, { 'ident': { type: options.source.type, uuid: options.source.uuid} });
-
-            if(target[0] && source[0]) {
-                createConnection([source[0].scope.guid, target[0].scope.guid], target[0].options, options.type);
-            }
-        }
-
-        function onConnectorDisonnect(options) {
-
-            if(connectorConnectionMap.length === 0) {
-                return;
-            }
-
-            if(typeof options.type === 'string') {
-                options.type = [ options.type ];
-            }
-
-            angular.forEach(options.type, function(type) {
-
-                var connections = loDash.filter(connectorConnectionMap, { type: type });
-
-                angular.forEach(connections, function(connection) {
-                    jsP.detachOriginal(connection.connection);
-                });
-
-                connectorConnectionMap = loDash.rest(connectorConnectionMap, { type: type });
-
-                var endpoints = loDash.filter(connectorEndpointMap, { type: type });
-
-                angular.forEach(endpoints, function(endpoint) {
-                    jsP.deleteEndpoint(endpoint.endpoint);
-                });
-
-                connectorEndpointMap = loDash.rest(connectorEndpointMap, { type: type });
-
-            });
-
-        }
-
-        function onProjectDraftDiscarded() {
-            connectorMap = [];
-            connectorEndpointMap = [];
-            connectorConnectionMap = [];
-        }
+    .directive('jsPlumbConnector', function ($rootScope, jsP, mappingArrows) {
 
         $rootScope.$on('$locationChangeStart', function() {
             jsP.detachEveryConnection({});
         });
-
-        PubSub.subscribe($rootScope, 'jsp-connector-connect', onConnectorConnect);
-        PubSub.subscribe($rootScope, 'jsp-connector-disconnect', onConnectorDisonnect);
-        PubSub.subscribe($rootScope, ['projectDraftDiscarded', 'restoreCurrentProject'], onProjectDraftDiscarded);
 
         return {
             scope: true,
             restrict: 'A',
             replace: true,
             compile: function(tElement, tAttrs) {
-                var jsPlumbConnectorOptions = tAttrs['jsPlumbConnectorOptions'],
-                    jsPlumbConnectorOptionsWatch = function(scope) {
-                        return scope.$eval(jsPlumbConnectorOptions);
-                    },
-                    jsPlumbConnectorIdentItem = tAttrs['jsPlumbConnectorIdentItem'],
+                var jsPlumbConnectorIdentItem = tAttrs['jsPlumbConnectorIdentItem'],
                     jsPlumbConnectorIdentItemWatch = function(scope) {
                         return scope.$eval(jsPlumbConnectorIdentItem);
                     };
 
-                connectorMap = [];
-                connectorEndpointMap = [];
-                connectorConnectionMap = [];
-
-                function pushConnectorMap(elem) {
-
-                    var connectorMapIndex = loDash.findIndex(connectorMap, {ident : { type: elem.ident.type, uuid: elem.ident.uuid }});
-                    if(connectorMapIndex < 0) {
-                        connectorMap.push(elem);
-                    } else {
-                        connectorMap[connectorMapIndex] = elem;
-                    }
-                }
+                mappingArrows.clear();
 
                 return function(scope, iElement) {
-                    var options = jsPlumbConnectorOptionsWatch(scope),
-                        identItem = jsPlumbConnectorIdentItemWatch(scope);
+                    var identItem = jsPlumbConnectorIdentItemWatch(scope),
+                        identType = tAttrs['jsPlumbConnectorIdentType'];
 
-                    options = angular.extend({}, defaultOpts, options);
-
-                    scope.guid = GUID.uuid4();
+                    scope.guid = mappingArrows.register(identItem, identType);
                     iElement.attr('id', scope.guid);
-
-                    var elem = {
-                        scope: scope,
-                        options: options,
-                        ident: {
-                            type: tAttrs['jsPlumbConnectorIdentType'],
-                            uuid: identItem
-                        }
-                    };
-
-                    pushConnectorMap(elem);
-
                 };
             }
         };

--- a/yo/app/scripts/services/js-plumb.js
+++ b/yo/app/scripts/services/js-plumb.js
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2013 – 2015  SLUB Dresden & Avantgarde Labs GmbH (<code@dswarm.org>)
- *  
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -122,7 +122,6 @@ angular.module('dmpApp')
 
         };
 
-
         /**
          * Create a new connection between two nodes, that is, it draws an arrow
          * unless configured otherwise. connection is directed from source to target
@@ -132,16 +131,23 @@ angular.module('dmpApp')
          * @returns {jsPlumb.Connection}
          */
         function connect(source, target, opts) {
-            var connection = jsPlumb.connect(angular.extend({
-                source: source,
-                target: target
-            }, jsPlumbOptions, opts || {}));
+            var connection;
+            try {
+                connection = jsPlumb.connect(angular.extend({
+                    source: source,
+                    target: target
+                }, jsPlumbOptions, opts || {}));
 
-            if (!source.data) {
-                source = $(source);
+                if (!source.data) {
+                    source = $(source);
+                }
+
+                source.data('_outbound', connection);
+            } catch (ignore) {
+                // when the UI is particularly slow, connect calls can happen before
+                // the element exists in the DOM.
+                // TODO: what to do in this case?
             }
-
-            source.data('_outbound', connection);
 
             return connection;
         }

--- a/yo/app/scripts/services/mapping-arrows.js
+++ b/yo/app/scripts/services/mapping-arrows.js
@@ -1,0 +1,253 @@
+/**
+ * Copyright (C) 2013 – 2015  SLUB Dresden & Avantgarde Labs GmbH (<code@dswarm.org>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+angular.module('dmpApp')
+    .factory('mappingArrows', function(jsPlumb, loDash, GUID, PubSub, convertUnits) {
+
+        var connectionMapping = [],
+            createdConnections = [],
+            createdEndpoints = [],
+            oneEmInPx = convertUnits.em2px(1),
+            halfEm = (oneEmInPx * 0.5) | 0; // jshint ignore:line
+
+
+        function createIdent(identifier, type) {
+            return {
+                ident: {
+                    uuid: identifier,
+                    type: type
+                }
+            };
+        }
+
+        function findConnectionIndex(identifier, type) {
+            var ident = type ? createIdent(identifier, type) : identifier;
+            return loDash.findIndex(connectionMapping, ident);
+        }
+
+        function findConnection(identifier, type) {
+            var index = findConnectionIndex(identifier, type);
+            if (index === -1) {
+                return undefined;
+            }
+            return connectionMapping[index];
+        }
+
+        function registerConnection(identifier, type) {
+            var ident = createIdent(identifier, type),
+                index = findConnectionIndex(ident),
+                guid = GUID.uuid4(),
+                content = angular.extend(ident, {guid: guid});
+
+            if (index === -1) {
+                connectionMapping.push(content);
+            } else {
+                connectionMapping[index] = content;
+            }
+
+            return guid;
+        }
+
+
+        function doBatched(fn) {
+            jsPlumb.doWhileSuspended(fn);
+        }
+
+        function createEndpoint(options, selector) {
+            return jsPlumb.addEndpoint(selector, options);
+        }
+
+        function plumbOptions() {
+            return {
+                container: 'transformation',
+                detachable: false,
+                anchor: [
+                    [0, 0.5, -1, 0, -halfEm, 0], // left with .5em offset
+                    [1, 0.5, 1, 0, halfEm, 0] // right with .5em offset
+                ],
+                endpoint: 'Blank',
+                connectorOverlays: [
+                    ['Arrow', {
+                        location: 1,
+                        width: halfEm,
+                        length: (oneEmInPx * 0.75) | 0, // jshint ignore:line
+                        foldback: 0.75
+                    }]
+                ],
+                connector: 'Straight',
+                connectorStyle: {
+                    strokeStyle: '#5E6C6D',
+                    lineWidth: 2
+                },
+                paintStyle: {
+                    fillStyle: '#5E6C6D',
+                    strokeStyle: 'black',
+                    lineWidth: 2
+                }
+            };
+        }
+
+        function plumbConnect(source, target, options) {
+            var connection;
+            var connectionOpts = {
+                source: source,
+                target: target
+            };
+
+            try {
+                connection = jsPlumb.connect(connectionOpts, options);
+                if (!source.data) {
+                    source = $(source);
+                }
+                source.data('_outbound', connection);
+            } catch (ignore) {
+                // when the UI is particularly slow,
+                // connect calls can happen before
+                // the element exists in the DOM.
+                // TODO: what to do in this case?
+            }
+
+            return connection;
+        }
+
+        function cacheCreatedEndpoints(endpoints, type) {
+            var wrapped = loDash.map(endpoints, function(endpoint) {
+                return {
+                    type: type,
+                    endpoint: endpoint
+                };
+            });
+
+            createdEndpoints.push.apply(createdEndpoints, wrapped);
+        }
+
+        function createEndpoints(selectors, type, options) {
+
+            var create = loDash.partial(createEndpoint, options);
+            var endpoints = loDash.map(selectors, create);
+
+            cacheCreatedEndpoints(endpoints, type);
+
+            return endpoints;
+        }
+
+        function createConnection(selectors, type, options) {
+            var endpoints = createEndpoints(selectors, type, options);
+            var connection = plumbConnect(endpoints[0], endpoints[1]);
+
+            createdConnections.push({
+                type: type,
+                connection: connection
+            });
+
+            return connection;
+        }
+
+        function connectOne(options, connection) {
+
+            var target = findConnection(connection.target.uuid, connection.target.type),
+                source = findConnection(connection.source.uuid, connection.source.type);
+
+            if(target && source) {
+                createConnection([source.guid, target.guid], connection.type, options);
+            }
+        }
+
+        function connectAll(connections) {
+            var opts = plumbOptions();
+            if (loDash.isArray(connections)) {
+                var connect = loDash.partial(connectOne, opts);
+                doBatched(function() {
+                    loDash.forEach(connections, connect);
+                });
+            } else {
+                connectOne(opts, connections);
+            }
+        }
+
+        function disconnectOneConnection(connection) {
+            if (loDash.isObject(connection) && connection.endpoints) {
+                try {
+                    jsPlumb.detach(connection);
+                } catch (ignore) {
+                    // when we call this function on elements that were already removed from the DOM,
+                    // some underlying call to jQuery(elem).offset() throws, since, well, there is no offset anymore.
+                    // We treat this case as a success, assuming the connection is detached.
+                }
+            }
+        }
+
+        function disconnectOneEndpoint(endpoint) {
+            try {
+                jsPlumb.deleteEndpoint(endpoint);
+            } catch (ignore) {
+                // when we call this function on elements that were already removed from the DOM,
+                // some underlying call to jQuery(elem).offset() throws, since, well, there is no offset anymore.
+                // We treat this case as a success, assuming the connection is detached.
+            }
+        }
+
+        function disconnectConnectionForType(type) {
+            var connections = loDash.filter(createdConnections, { type: type });
+            loDash.forEach(connections, function(connection) {
+                disconnectOneConnection(connection.connection);
+            });
+            createdConnections = loDash.reject(createdConnections, { type: type });
+        }
+
+        function disconnectEndpointForType(type) {
+            var endpoints = loDash.filter(createdEndpoints, { type: type });
+            loDash.forEach(endpoints, function(endpoint) {
+                disconnectOneEndpoint(endpoint.endpoint);
+            });
+            createdEndpoints = loDash.reject(createdEndpoints, { type: type });
+        }
+
+        function disconnectAll(options) {
+
+            if (loDash.isEmpty(createdConnections)) {
+                return;
+            }
+
+            if (loDash.isString(options.type)) {
+                options.type = [ options.type ];
+            }
+
+            doBatched(function() {
+                loDash.forEach(options.type, function(type) {
+                    disconnectConnectionForType(type);
+                    disconnectEndpointForType(type);
+                });
+            });
+        }
+
+        function clear() {
+            connectionMapping = [];
+            createdConnections = [];
+            createdEndpoints = [];
+        }
+
+        // TODO: subscribe elsewhere and expose methods?
+        PubSub.subscribe(null, ['projectDraftDiscarded', 'restoreCurrentProject'], clear);
+        PubSub.subscribe(null, 'jsp-connector-connect', connectAll);
+        PubSub.subscribe(null, 'jsp-connector-disconnect', disconnectAll);
+
+        return {
+            register: registerConnection,
+            clear: clear
+        };
+    });

--- a/yo/app/scripts/services/pubsub.js
+++ b/yo/app/scripts/services/pubsub.js
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2013 – 2015  SLUB Dresden & Avantgarde Labs GmbH (<code@dswarm.org>)
- *  
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -51,6 +51,8 @@ angular.module('dmpApp').
          * @param callback {Function(*, event)}
          */
         function subscribe(scp, channel, callback) {
+
+            scp = scp || $rootScope;
 
             if(!scp._off) {
                 scp._off = {};

--- a/yo/app/scripts/services/transformation-arrows.js
+++ b/yo/app/scripts/services/transformation-arrows.js
@@ -16,7 +16,7 @@
 'use strict';
 
 angular.module('dmpApp')
-    .factory('mappingArrows', function(jsPlumb, loDash, GUID, PubSub, convertUnits) {
+    .factory('transformationArrows', function(jsPlumb, loDash, GUID, PubSub, convertUnits) {
 
         var connectionMapping = [],
             createdConnections = [],

--- a/yo/app/styles/views/mapping.less
+++ b/yo/app/styles/views/mapping.less
@@ -400,15 +400,49 @@ button.close-transformation-selector {
 
 }
 
+.mapping-component {
+  width: 5em;
+  height: 5em;
+  padding: 0;
+
+  z-index: 42;
+  color: #004756;
+  background-color: white;
+  border: 1px solid #346789;
+  position: absolute;
+  cursor: pointer;
+  .box-shadow(0px 0px 1.5em #aaa);
+
+  &:hover {
+    .box-shadow(0px 0px 0.5em 0.3em hsla(184, 7%, 40%, 0.6)); // ##5E6C6D
+    opacity: 0.9;
+  }
+
+  .mapping-component-name {
+    margin-top: 1.4em;
+    display: inline-block;
+  }
+}
+
+
+.gridster-wrapper {
+  margin-left: 8em;
+  background: rgba(0, 0, 0, .1);
+
+  &::before {
+    content: "";
+    background: rgba(0, 0, 0, .1);
+    left: 0px;
+    height: 100%;
+    width: 8em;
+    position: absolute;
+  }
+}
+
 .gridster {
   position: relative;
   margin: auto;
-  background: rgba(0, 0, 0, .1);
   height: 0;
-}
-
-}
-
 }
 
 .gridster ul {
@@ -461,22 +495,6 @@ button.close-transformation-selector {
   z-index: 3;
 }
 
-.gridster .gridster-item {
-  -webkit-box-shadow: 0 0 5px rgba(0, 0, 0, 0.3);
-}
-
-.gridster .gridster-item {
-  -moz-box-shadow: 0 0 5px rgba(0, 0, 0, 0.3);
-  box-shadow: 0 0 5px rgba(0, 0, 0, 0.3);
-  color: #004756;
-}
-
-.gridster .gridster-item {
-  background: #ffffff;
-  padding: 10px;
-}
-
-
 .input-attribute-path-badge {
   cursor: pointer;
 }
@@ -488,11 +506,11 @@ button.close-transformation-selector {
 }
 
 .transformation-inputs {
-  left: 10px;
+  left: -2em;
 }
 
 .transformation-output {
-  right: 10px;
+  right: -1em;
 }
 
 .transformation-inputs li,
@@ -573,8 +591,12 @@ button.close-transformation-selector {
 }
 
 
-.transformation-inputs, .transformation-output, ._jsPlumb_connector, ._jsPlumb_endpoint {
+.transformation-inputs, .transformation-output {
   z-index: 1000;
+
+  & > ._jsPlumb_connector, ._jsPlumb_endpoint {
+    z-index: 1000;
+  }
 }
 
 .configurationSortable .list {

--- a/yo/app/styles/views/mapping.less
+++ b/yo/app/styles/views/mapping.less
@@ -407,14 +407,8 @@ button.close-transformation-selector {
   height: 0;
 }
 
-.gridster-loaded {
-  -webkit-transition: height .3s;
 }
 
-.gridster-loaded {
-  -moz-transition: height .3s;
-  -o-transition: height .3s;
-  transition: height .3s;
 }
 
 .gridster ul {
@@ -441,16 +435,6 @@ button.close-transformation-selector {
   display: block;
 }
 
-.gridster-loaded .gridster-item {
-  -webkit-transition: opacity .3s, left .3s, top .3s, width .3s, height .3s;
-}
-
-.gridster-loaded .gridster-item {
-  -moz-transition: opacity .3s, left .3s, top .3s, width .3s, height .3s;
-  -o-transition: opacity .3s, left .3s, top .3s, width .3s, height .3s;
-  transition: opacity .3s, left .3s, top .3s, width .3s, height .3s;
-}
-
 .gridster-mobile .gridster-item {
   position: static;
   float: none;
@@ -471,18 +455,6 @@ button.close-transformation-selector {
   background-color: #fff;
   border-color: #fff;
   opacity: 0.2;
-}
-
-.gridster .gridster-item-moving,
-.gridster .gridster-preview-holder {
-  -webkit-transition: opacity 0s, left 0s, top 0s, width 0s, height 0s;
-}
-
-.gridster .gridster-item-moving,
-.gridster .gridster-preview-holder {
-  -moz-transition: opacity 0s, left 0s, top 0s, width 0s, height 0s;
-  -o-transition: opacity 0s, left 0s, top 0s, width 0s, height 0s;
-  transition: opacity 0s, left 0s, top 0s, width 0s, height 0s;
 }
 
 .gridster .gridster-item-moving {
@@ -743,12 +715,6 @@ button.close-transformation-selector {
 
   .opacity(0.9);
 
-  -webkit-transition: all 0.3s;
-  -moz-transition: all 0.3s;
-  -ms-transition: all 0.3s;
-  -o-transition: all 0.3s;
-  transition: all 0.3s;
-
   z-index: 1000;
 
   &.offCanvasToggleButtonLeft {
@@ -793,11 +759,6 @@ button.close-transformation-selector {
 
   position: absolute;
   background-color: #363C3C;
-  -webkit-transition: all 0.3s;
-  -moz-transition: all 0.3s;
-  -ms-transition: all 0.3s;
-  -o-transition: all 0.3s;
-  transition: all 0.3s;
 
   .dataOuter {
     z-index: 1000;

--- a/yo/app/styles/views/mapping.less
+++ b/yo/app/styles/views/mapping.less
@@ -945,7 +945,7 @@ button.close-transformation-selector {
   margin: -1em;
   padding: 1em;
 
-  overflow: hidden;
+  overflow: auto;
 
   &.offCanvasShow {
     left: 30%;

--- a/yo/app/views/directives/transformation.html
+++ b/yo/app/views/directives/transformation.html
@@ -36,7 +36,6 @@
                         class="input-attribute-path-badge"
                         ng-click="onFilterClick(iap)"
                         js-plumb-connector
-                        js-plumb-connector-options="jsPlumbOpts"
                         js-plumb-connector-ident-type="transformation-input"
                         js-plumb-connector-ident-item="iap.uuid">{{ formatAttributePath(iap.attribute_path) }} <small>{{formatFilters(iap)}}</small></span>
                 </li>
@@ -48,37 +47,37 @@
                 <li ng-repeat="oap in output_attribute_paths">
                     <span
                         js-plumb-connector
-                        js-plumb-connector-options="jsPlumbOpts"
                         js-plumb-connector-ident-type="transformation-output"
                         js-plumb-connector-ident-item="oap.attribute_path.uuid">{{ formatAttributePath(oap.attribute_path) }}</span>
                 </li>
             </ul>
         </div>
 
-        <div gridster="gridsterOpts">
-            <ul>
+        <div class="gridster-wrapper">
+            <div gridster="gridsterOpts">
+                <ul>
                 <span ng-repeat="item in gridItems">
                     <span ng-if="item.placeholder">
                         <li gridster-item="customItemMap" class='gridster-preview' ng-click="onFunctionClick(item)" x-drop-target="true" x-on-drop="dropped(dragEl, dropEl)"></li>
                     </span>
                     <span ng-if="!item.placeholder">
-                        <li gridster-item="customItemMap" ng-class="{'gridster-preview': item.placeholder}" ng-click="onFunctionClick(item)">
-                            {{item.component.function.name}}
-
-                            <i class="glyphicon glyphicon-unchecked"
-                               ng-click="onMultipleComponentInputAdd(item)"
-                               js-plumb-connector
-                               js-plumb-connector-options="jsPlumbOpts"
-                               js-plumb-connector-ident-type="component"
-                               js-plumb-connector-ident-item="item.uuid"></i>
-
+                        <li class="mapping-component"
+                            gridster-item="customItemMap"
+                            ng-class="{'gridster-preview': item.placeholder}"
+                            ng-click="onFunctionClick(item)"
+                            js-plumb-connector
+                            js-plumb-connector-ident-type="component"
+                            js-plumb-connector-ident-item="item.uuid"
+                            >
+                            <span class="mapping-component-name">{{item.component.function.name}}</span>
                             <span ng-if="isMultiple(item.component) && hasOpenEndedComponents()">
                                 <i class="glyphicon glyphicon-plus" ng-click="onMultipleComponentInputAdd(item)"></i>
                             </span>
                         </li>
                     </span>
                 </span>
-            </ul>
+                </ul>
+            </div>
         </div>
 
     </div>

--- a/yo/bower.json
+++ b/yo/bower.json
@@ -3,25 +3,25 @@
   "version": "0.0.0",
   "dependencies": {
     "angular": "1.2.13",
-    "angular-bootstrap": "~0.10.0",
+    "angular-bootstrap": "0.10.0",
     "angular-cookies": "1.2.13",
     "angular-grid": "avantgarde-labs/ng-grid#2.0.9-1",
-    "angular-local-storage": "*",
+    "angular-local-storage": "0.2.2",
     "angular-resource": "1.2.13",
     "angular-route": "1.2.13",
     "angular-sanitize": "1.2.13",
-    "angular-ui-utils": "~0.1.1",
-    "angular-ui-sortable": "~0.12.6",
+    "angular-ui-utils": "0.1.1",
+    "angular-ui-sortable": "0.12.11",
     "angular-perfect-scrollbar": "chrode/angular-perfect-scrollbar#f90ea606d0805ac61634458e58b5172a0757fc22",
-    "bootstrap": "~3.1.1",
-    "es5-shim": "~2.1.0",
-    "font-awesome": "~4.4.0",
-    "humanize": "~0.0.8",
-    "jquery": "~2.0.3",
-    "jquery-ui": "~1.10.3",
+    "bootstrap": "3.1.1",
+    "es5-shim": "2.3.0",
+    "font-awesome": "4.4.0",
+    "humanize": "0.0.9",
+    "jquery": "1.11.3",
+    "jquery-ui": "1.10.4",
     "jsPlumb": "1.5.5",
-    "json3": "~3.3.0",
-    "lodash": "~2.4.0",
+    "json3": "3.3.2",
+    "lodash": "2.4.2",
     "ngprogress": "chrode/ngProgress#8cc05a6d63efec9c867ebac87fec94a5e405722e",
     "angular-gridster": "chrode/angular-gridster#03985e2483e24ce841d19e6d3b1c458d67edf416",
     "angular-ui-tree": "2.1.4"
@@ -50,7 +50,6 @@
     }
   },
   "resolutions": {
-    "jquery": "^1.8.0",
     "es5-shim": "2.3.0"
   }
 }


### PR DESCRIPTION
ping @zazi @chrode 

A couple of things here:

The main issue with weirdly drawn arrows was a timing issue:
1.  Gridster applies animations to its elements, but fires 'drag end' events before these animations have finished.
2. We already had _some_ window that we would wait after such an dragend event.
3. That window was nowhere near long enough.
4. Newer gridster versions try to fire an additional event _after_ the transition have finished, but we cannot upgrade gridster that easily (it breaks code, a lot of it; or rather, it shows incidental coupling we oughta resolve anyway…)
5. If we call jsplumb a millisecond too early, it would draw arrows to the components at the place the were in that particular moment, which then looks like arrows pointing to nothing. It might also choose to get really confused and then it messes up quite a lot.
6. Also, the so called 'angular-gridster' is not really angular, as it fires its events outside of `$digest`.

I have unified drag handlers, increased the 'wait for everything to fall in place' time window and removed some additional animations. As a result, we draw the arrows far more often at the right time, although it **still can happen** that we miss our window in which case we see some weird drawing errors (as before, only slightly more beautiful). This is very dependent on the browser and machine of the user and the complexity of the mappings. The more it needs to animate everything in place, the more risk is there to draw too early. If we spent time in upgrading gridster and controlling the animations, we can possibly achieve to draw only after everything is in place, _deterministically_.

Also, some events were misfired. Closing the mapping, would, instead of _removing_ the arrows, ask for them to be redrawn. I also batched the drawing of the mapping arrows. Before, with every call the `createEndpoint` and `createConnection`, jsplumb would go the screen and do its drawing, giving it ample opportunity to mess up. Now, we first add all new connections and have one bigger repaint at the end.

I fixed some other bugs along the way, most prominently one can now scroll an opened configuration view. No more need to decrease the browser zoom to configure an SQL query.

Implementation wise, there is some duplicated content in the new transformation arrows directive and the already existing jsP directive. This should be cleaned up after the new mapping arrows is in place.
