### PR TITLE
[BUGFIX][DD-1290] check, whether transformation is available @ mapping

### DIFF
--- a/yo/app/scripts/services/util.js
+++ b/yo/app/scripts/services/util.js
@@ -201,6 +201,11 @@ angular.module('dmpApp')
 
             loDash.map(mappings, function(mapping, idx) {
 
+                if(loDash.isUndefined(mapping.transformation)) {
+
+                    return;
+                }
+
                 loDash.forEach(mapping.transformation.parameter_mappings, function(parameter_mapping, key) {
 
                     if(key.indexOf('TRANSFORMATION_OUTPUT_VARIABLE') === -1) {


### PR DESCRIPTION
@chrode I'm not sure whether this is enough (or whether other parts are also affected from the big rework from DD-1274), since e.g. the "$scope.activeMapping" variable in transformation.js seems to be empty (i.e. is undefined/not bind) when the result message is created after task preview, see https://github.com/zazi/dswarm-backoffice-web/blob/dd-1290/yo/app/scripts/directives/transformation.js#L1069. At the state from DD-1255 (https://github.com/zazi/dswarm-backoffice-web/commit/7a16790f3ce10836ad724d51947bcec771ee643d) task preview after project seem to work. So I guess it has something to do with big rework from DD-1274. // @knutwalker 
